### PR TITLE
Add status code additionally to error message

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -14,5 +14,6 @@ type UserAuth struct {
 }
 
 type AuthResponse struct {
+	Code uint
 	Error string
 }


### PR DESCRIPTION
This way client (User/Agent) which requested authorization
can distinguish between different errors by error code and not by error message.
Also api can freely change error messages without breaking interface contract
as long as error code isn't changed too.

In other words, if Agent wants to authorize, and wants to know why authorization failed (server errror, or bad credentials) it needs to depend on error message - this is not good as people like to change messages and you need to remember that changing error message might actually break interaction with Agent/User.

In place of Code I also propose to use standard http status codes (200, 401, 403, 404, 500):
Pros:
- We don't invent the wheel
- http status codes are already commonly understood and well described
- This can simplify things as in case of REST part of api we can simply fetch Code and Error from AuthResponse and send it as header
- We keep REST and WS controllers close together where only difference is method of transportation. This is good for api and for clients (User/Agent) as both protocols will basically behave the same (doesn't matter if you use WS or REST, code=200 means auth was successful).

Cons:
- http status codes are limited and at some point there might be desire to add new one as a specific error
