### PR TITLE
Add unique cmd id so User can distinguish for which cmd is the response

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -47,6 +47,7 @@ type Cmd struct {
 	Service   string `json:",omitempty"` // omit for agent, else one of Services
 	Data      []byte `json:",omitempty"` // struct for Cmd, if any
 	// --
+	CmdId string `json:",omitempty"` // set by User
 	RelayId string `json:",omitempty"` // set by API
 }
 
@@ -56,6 +57,7 @@ type Reply struct {
 	Error string // success if empty
 	Data  []byte `json:",omitempty"`
 	// --
+	CmdId string `json:",omitempty"` // set by User
 	RelayId string // set by API
 }
 
@@ -109,6 +111,7 @@ func (cmd *Cmd) Reply(err error, data interface{}) *Reply {
 	// todo: encoding/json or websocket.JSON doesn't seem to handle error type
 	reply := &Reply{
 		Cmd:     cmd.Cmd,
+		CmdId:   cmd.CmdId,
 		RelayId: cmd.RelayId,
 	}
 	if err != nil {

--- a/proto_test.go
+++ b/proto_test.go
@@ -16,6 +16,7 @@ var _ = Suite(&TestSuite{})
 
 func (s *TestSuite) TestReply(t *C) {
 	cmd := &proto.Cmd{
+		CmdId:     "0x02",        // normally set by User
 		RelayId:   "0x01",        // normally set by API
 		AgentUuid: "abc-123-def", // fake uuid
 		Cmd:       "StartService",
@@ -23,6 +24,7 @@ func (s *TestSuite) TestReply(t *C) {
 	}
 	got := cmd.Reply(nil, nil)
 	expect := &proto.Reply{
+		CmdId:   "0x02",
 		RelayId: "0x01",
 		Cmd:     "StartService",
 		Error:   "",


### PR DESCRIPTION
Consider this:
1. User sends cmd1 to api
2. User sends cmd2 to api
3. User recv reply1 - success
4. User recv reply2 - fail

The question is which cmd was successful? cmd1 or cmd2?

If we assume that cmds can be processed in parallel
then there is no way for User to know that
without introducing unique cmd id filled by User.
